### PR TITLE
Quick: Stable Package.json Calls & Add Homepage

### DIFF
--- a/bin/version.js
+++ b/bin/version.js
@@ -3,8 +3,9 @@
 /** Create CSS file to import that prints project version */
 
 const fs = require('fs');
-const path = require('../package.json');
 const childProcess = require('child_process');
+
+const package = require(process.env.npm_package_json);
 
 
 
@@ -14,11 +15,12 @@ const childProcess = require('child_process');
  */
 function create(outputPath) {
     // Get data
-    const appName = process.env.npm_package_name;
-    const appLicense = path.license;
+    const appName = package.name;
+    const appLicense = package.license;
     const appGitRef = childProcess.execSync('git describe --always').toString();
+    const appWebsite = package.homepage.replace('https://', '');
     const fileContent = `/*! ${appName} ${appGitRef.replace("\n", "")} `
-                        + `| ${appLicense} | github.com/TACC/Core-Styles */`
+                        + `| ${appLicense} | ${appWebsite} */`
                         + "\n";
 
     // Tell user

--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,7 @@
 
 const { program } = require('commander');
 
-const package = require('./package.json');
+const package = require(process.env.npm_package_json);
 
 const {
     buildStylesheets,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "bugs": {
     "url": "https://github.com/tacc-wbomar/Core-Styles/issues"
   },
-  "homepage": "https://github.com/tacc-wbomar/Core-Styles#readme",
+  "homepage": "https://github.com/tacc-wbomar/Core-Styles",
   "repository": "git@github.com:tacc-wbomar/Core-Styles.git",
   "devDependencies": {
     "yarn": "^1.22.17"

--- a/source/_version.css
+++ b/source/_version.css
@@ -1,1 +1,1 @@
-/*! @tacc/core-styles v0.1.0-9-g7f3eeab | MIT | github.com/TACC/Core-Styles */
+/*! @tacc/core-styles v0.1.0-13-g4f2aa5b | MIT | github.com/tacc-wbomar/Core-Styles */


### PR DESCRIPTION
### Overview

Load `package.json` of "lifecycle script" reliably.
Use homepage form `package.json`.

### Related

#### Required By

- https://github.com/TACC/Core-CMS/pull/448

### Changes

- Fix variable name from `path` to `package`.
- Do not depend on assumed relative directory for `package.json`.
- Make calls to `package.json` using reliable path from NPM.
- Add and use `package.json` homepage.

### Testing

✓ I tested `npm run build` on user repo https://github.com/TACC/Core-CMS/tree/test/core-styles--solution-b.

### Notes

I discovered these changes when I found `process.env.npm_package_homepage` was `undefined` then came across:
https://github.com/npm/rfcs/blob/main/implemented/0021-reduce-lifecycle-script-environment.md#detailed-explanation